### PR TITLE
Update README to fix bad paths and input/output

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ $ age-plugin-tpm --generate -o age-identity.txt
 $ age-plugin-tpm -y age-identity.txt > age-recipient.txt
 
 # Encrypt / Decrypt something
-$ echo "Hack The Planet" | age -R ./age-recipient.txt -o test-decrypt.txt
-$ age --decrypt -i ./age-identity.txt -o - test-decrypt.txt
+$ echo 'Hack The Planet' | age -R age-recipient.txt -o test-decrypt.txt
+$ age --decrypt -i age-identity.txt -o - test-decrypt.txt
 Hack The Planet!
 ```
 
@@ -49,12 +49,12 @@ Hack The Planet!
 
 ```bash
 # Create identity
-$ AGE_TPM_PIN=123 age-plugin-tpm --generate --pin -o age-identity.txt
-$ age-plugin-tpm -y age-identity > age-recipient.txt
+$ age-plugin-tpm --generate --pin -o age-identity.txt
+$ age-plugin-tpm -y age-identity.txt > age-recipient.txt
 
 # Encrypt / Decrypt something
-$ echo "Hack The Planet" | age -R ./age-recipient.txt -o test-decrypt.txt
-$ AGE_TPM_PIN=123 age --decrypt -i ./age-identity.txt -o - test-decrypt.txt
+$ echo 'Hack The Planet' | age -R age-recipient.txt -o test-decrypt.txt
+$ age --decrypt -i age-identity.txt -o - test-decrypt.txt
 Hack The Planet!
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,21 +40,26 @@ $ age-plugin-tpm --generate -o age-identity.txt
 $ age-plugin-tpm -y age-identity.txt > age-recipient.txt
 
 # Encrypt / Decrypt something
-$ echo 'Hack The Planet' | age -R age-recipient.txt -o test-decrypt.txt
+$ echo 'Hack The Planet!' | age -R age-recipient.txt -o test-decrypt.txt
 $ age --decrypt -i age-identity.txt -o - test-decrypt.txt
 Hack The Planet!
 ```
 
-### With PIN
+You can add `--pin` when calling `--generate` to require a PIN when encrypting or decrypting.
+
+### When used non-interactively
+
+If you want to use a `--pin` non-interactively, you can use the `AGE_TPM_PIN` environment variable.
+Please be aware that environment variables are not secure, and can be read from `/proc/$PID/environ`.
 
 ```bash
 # Create identity
-$ age-plugin-tpm --generate --pin -o age-identity.txt
+$ AGE_TPM_PIN=1234 age-plugin-tpm --generate --pin -o age-identity.txt
 $ age-plugin-tpm -y age-identity.txt > age-recipient.txt
 
 # Encrypt / Decrypt something
-$ echo 'Hack The Planet' | age -R age-recipient.txt -o test-decrypt.txt
-$ age --decrypt -i age-identity.txt -o - test-decrypt.txt
+$ echo 'Hack The Planet!' | age -R age-recipient.txt -o test-decrypt.txt
+$ AGE_TPM_PIN=1234 age --decrypt -i age-identity.txt -o - test-decrypt.txt
 Hack The Planet!
 ```
 


### PR DESCRIPTION
This pull request updates the README to fix some bad paths (the example didn't work) and aligns the input with the output.

Additionally, rather than hinting that `AGE_TPM_PIN` is how you might use a pin, I update the copy to say that this is how you might use the plugin non-interactively, instead.

`--pin` will prompt when encrypting and decrypting, no environment variable required.