### PR TITLE
plugin/tpm: support persisted shared SRKs

### DIFF
--- a/plugin/crypto.go
+++ b/plugin/crypto.go
@@ -103,7 +103,7 @@ func DecryptFileKeyTPM(tpm transport.TPMCloser, identity *Identity, remoteKey, f
 
 	// We'll be using the SRK for the session encryption, and we need it as the
 	// parent for our application key. Make sure it's created and available.
-	srkHandle, srkPublic, err := CreateSRK(tpm)
+	srkHandle, srkPublic, err := AcquireIdentitySRK(tpm, identity)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/identity_test.go
+++ b/plugin/identity_test.go
@@ -17,6 +17,12 @@ func mustPrivate(data []byte) tpm2.TPM2BPrivate {
 	}
 }
 
+func mustSRK(data []byte) *tpm2.TPM2BName {
+	return &tpm2.TPM2BName{
+		Buffer: data,
+	}
+}
+
 var data = []struct {
 	key string
 	t   *Identity
@@ -36,6 +42,25 @@ var data = []struct {
 			PIN:     HasPIN,
 			Public:  mustPublic([]byte("public")),
 			Private: mustPrivate([]byte("private")),
+		},
+	},
+	{
+		key: "AGE-PLUGIN-TPM-1QGQQQPNSW43XC6TRQQRHQUNFWESHGEGQQDEHY6CUT4TFU",
+		t: &Identity{
+			Version: 2,
+			Public:  mustPublic([]byte("public")),
+			Private: mustPrivate([]byte("private")),
+			SRKName: mustSRK([]byte("srk")),
+		},
+	},
+	{
+		key: "AGE-PLUGIN-TPM-1QGQSQPNSW43XC6TRQQRHQUNFWESHGEGQQDEHY6CHRM9KS",
+		t: &Identity{
+			Version: 2,
+			PIN:     HasPIN,
+			Public:  mustPublic([]byte("public")),
+			Private: mustPrivate([]byte("private")),
+			SRKName: mustSRK([]byte("srk")),
 		},
 	},
 }


### PR DESCRIPTION
Currently, the plugin will attempt to create a new storage primary every time an operation involving the TPM is performed. This is not only inefficient (since deriving such a primary can be an expensive operation), it also breaks on systems where the TPM has a password set for the owner hierarchy, which causes `CreatePrimary` to fail with `TPM_RC_BAD_AUTH`.

However, by convention, the standard TCG shared SRK is usually persisted in NVRAM at index `0x81000001`, which allows applications to just skip the expensive `CreatePrimary` call when the SRK is present at this location. This PR adds support for using this persisted shared SRK to age-plugin-tpm, addressing both issues outlined earlier.