### PR TITLE
Fix decryption with multiple recipients

### DIFF
--- a/cmd/age-plugin-tpm/testdata/script/tests.txt
+++ b/cmd/age-plugin-tpm/testdata/script/tests.txt
@@ -19,5 +19,28 @@ stdin encrypted.txt
 exec age --decrypt -i ./age-identity.txt -o -
 stdout 'Hello World'
 
+# Encrypt to multiple recipients and decrypt
+exec age-plugin-tpm -g -o identity.txt
+exec age-plugin-tpm -y identity.txt -o recipient.txt
+exec age-plugin-tpm -g -o identity2.txt
+exec age-plugin-tpm -y identity2.txt -o recipient2.txt
+exec cat recipient.txt recipient2.txt
+stdin stdout
+exec tee recipients.txt
+exec cat recipient2.txt recipient.txt
+stdin stdout
+exec tee recipients-swapped.txt
+stdin input.txt
+exec age -R recipients.txt -o secret.age
+stdin secret.age
+exec age -i identity.txt -d
+stdout 'Hello World'
+stdin input.txt
+exec age -R recipients-swapped.txt -o secret.age
+stdin secret.age
+exec age -i identity.txt -d
+stdout 'Hello World'
+exec rm identity.txt identity2.txt recipient.txt recipient2.txt recipients.txt recipients-swapped.txt
+
 -- input.txt --
 Hello World

--- a/plugin/identity.go
+++ b/plugin/identity.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"crypto/ecdh"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -84,7 +85,11 @@ func (i *Identity) Unwrap(stanzas []*age.Stanza) (fileKey []byte, err error) {
 		default:
 			continue
 		}
-		return resp.Unwrap([]*age.Stanza{stanza})
+		fileKey, err := resp.Unwrap([]*age.Stanza{stanza})
+		if errors.Is(err, age.ErrIncorrectIdentity) {
+			continue
+		}
+		return fileKey, err
 	}
 	return nil, age.ErrIncorrectIdentity
 }


### PR DESCRIPTION
Seems like Identity.Unwrap() was returning too early, i.e. on identity mismatch. The simplest fix was just to check if `err == nil` and return the filekey. Ended up checking for incorrect identity and propagating errors if there's something else.

Fixes #38 #39 